### PR TITLE
updated to reflect new bfs-nr field in csv file

### DIFF
--- a/src/Resolver.php
+++ b/src/Resolver.php
@@ -273,6 +273,7 @@ class Resolver
                     $record['city'],
                     $record['extraDigit'],
                     $record['commune'],
+                    $record['bfsNr'],
                     $record['canton'],
                     $record['east'],
                     $record['north'],
@@ -365,12 +366,13 @@ class Resolver
         array_shift($dataLines); // we don't need the headers
         $parsedData = [];
         foreach ($dataLines as $line) {
-            list($city, $zipcode, $extraDigit, $commune, $canton, $east, $north) = str_getcsv($line, ';');
+            list($city, $zipcode, $extraDigit, $commune, $bfsNr, $canton, $east, $north) = str_getcsv($line, ';');
             $parsedData[$zipcode] = [
                 'zipcode'    => $zipcode,
                 'city'       => $city,
                 'extraDigit' => $extraDigit,
                 'commune'    => $commune,
+                'bfsNr'     => $bfsNr,
                 'canton'     => $canton,
                 'east'       => $east,
                 'north'      => $north

--- a/src/Result.php
+++ b/src/Result.php
@@ -66,6 +66,14 @@ class Result
      */
     public $canton;
 
+
+    /**
+     * Canton (BFS-Nr)
+     *
+     * @var string
+     */
+    public $bfsNr;
+
     /**
      * East coordinate
      * 
@@ -94,18 +102,20 @@ class Result
      * @param string $city
      * @param int $extraDigit
      * @param string $commune
+     * @param string $bfsNr
      * @param string $canton
      * @param int $east
      * @param int $north
      * @param bool $validZipCode
      */
-    public function __construct($zipcode, $city = '', $extraDigit = 0, $commune = '', $canton = '', 
+    public function __construct($zipcode, $city = '', $extraDigit = 0, $commune = '', $bfsNr = '', $canton = '',
                                 $east = 0, $north = 0, $validZipCode = false)
     {
         $this->zipcode      = $zipcode;
         $this->city         = $city;
         $this->extraDigit   = $extraDigit;
         $this->commune      = $commune;
+        $this->bfsNr      = $bfsNr;
         $this->canton       = $canton;
         $this->east         = $east;
         $this->north        = $north;
@@ -221,6 +231,7 @@ class Result
         $xml->addChild('city', $this->city);
         $xml->addChild('extraDigit', $this->extraDigit);
         $xml->addChild('commune', $this->commune);
+        $xml->addChild('bfsNr', $this->bfsNr);
         $xml->addChild('canton', $this->canton);
         $xml->addChild('east', $this->east);
         $xml->addChild('north', $this->north);


### PR DESCRIPTION
The csv file contains a new field called BFS-Nr. If this new field is not included, you get this number instead of the canton